### PR TITLE
[codex] Expose autocorrelation path mode

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -215,6 +215,7 @@ phase_only = False
 distance_range = -1/50000
 azimuth_range = -1/360
 group_pair_mode = all
+autocorr_mode = off
 windows_per_xcache = AUTO
 xcache_async_after_sac2spec = True
 async_poll_sec = 5
@@ -258,6 +259,9 @@ Common field formats:
 - `azimuth_range`: `min/max` in degrees; `-1/360` is effectively unlimited.
 - `group_pair_mode`: `intra` for within-group pairs, `inter` for cross-group
   pairs, or `all` for both.
+- `autocorr_mode`: autocorrelation path control. Use `off` to exclude station
+  self-pairs, `include` to add self-pairs to normal station pairs, or `only`
+  to keep only self-pairs.
 
 `[geometry].external_geo_tsv` points to an optional external station-coordinate
 TSV. `NONE` means coordinates are read from SAC header fields

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ phase_only = False
 distance_range = -1/50000
 azimuth_range = -1/360
 group_pair_mode = all
+autocorr_mode = off
 windows_per_xcache = AUTO
 xcache_async_after_sac2spec = True
 async_poll_sec = 5
@@ -239,6 +240,8 @@ debug = False
 - `distance_range`：`min/max`，单位 km；`-1/50000` 基本等于不限制。
 - `azimuth_range`：`min/max`，单位度；`-1/360` 基本等于不限制。
 - `group_pair_mode`：`intra` 只算同组，`inter` 只算组间，`all` 全部计算。
+- `autocorr_mode`：自相关路径开关。`off` 关闭自相关，`include` 在普通台站对
+  之外加入自相关，`only` 只保留自相关。
 
 `[geometry].external_geo_tsv` 用于提供外部台站坐标表。`NONE` 表示从 SAC
 header 的 `STLA/STLO/STEL` 读取坐标；当 SAC header 缺少坐标、坐标不可靠，

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -180,6 +180,7 @@ A7K2	38.499907	-98.603619	0	KS	00
 | `distance_range` | 允许距离范围，格式 `min/max`，单位 km。`-1/50000` 基本等于不限制。 |
 | `azimuth_range` | 允许方位角范围，格式 `min/max`，单位度。 |
 | `group_pair_mode` | 组间规则：`intra` 仅同组，`inter` 仅不同组，`all` 同组和组间都计算。 |
+| `autocorr_mode` | 自相关路径控制：`off` 关闭自相关，`include` 在普通台站对外加入自相关，`only` 只保留自相关。 |
 | `windows_per_xcache` | 每个 xcache shard 包含的窗口数；`AUTO` 表示按时间片集中写入。 |
 | `xcache_async_after_sac2spec` | SAC2SPEC 每完成一个时间片就异步构建 xcache。 |
 | `async_poll_sec` | 所有异步任务的轮询间隔，单位秒；包括 xcache、spack 清理和 SourcePack。 |

--- a/docs/OUTPUTS.md
+++ b/docs/OUTPUTS.md
@@ -46,7 +46,8 @@ workspace_dir/
 | `path_plan/allowed_path_ids.txt` | 原生 XC 使用的 path id 白名单。 |
 
 如果 `allowed_paths.tsv` 的行数不符合预期，优先检查 `sta_list`、
-`external_geo_tsv`、`distance_range`、`azimuth_range` 和 `group_pair_mode`。
+`external_geo_tsv`、`distance_range`、`azimuth_range`、`group_pair_mode` 和
+`autocorr_mode`。
 
 ## `run`: SAC2SPEC
 

--- a/example/config.ini
+++ b/example/config.ini
@@ -51,6 +51,7 @@ phase_only = False
 distance_range = -1/50000
 azimuth_range = -1/360
 group_pair_mode = all
+autocorr_mode = off
 windows_per_xcache = AUTO
 xcache_async_after_sac2spec = True
 async_poll_sec = 5

--- a/fastxc/cli.py
+++ b/fastxc/cli.py
@@ -177,6 +177,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
             print(f"  xc: {cfg.executables.xc}")
             print(f"  pws: {cfg.executables.pws}")
             print(f"  tfpws: {cfg.executables.tfpws}")
+            print(f"  autocorr_mode: {cfg.xcorr.autocorr_mode}")
             windows = cfg.xcache.windows_per_xcache
             print(f"  windows_per_xcache: {windows if windows is not None else 'AUTO'}")
             print(f"  xcache_async_after_sac2spec: {cfg.xcache.async_after_sac2spec}")

--- a/fastxc/config_parser/schema.py
+++ b/fastxc/config_parser/schema.py
@@ -69,6 +69,18 @@ def _normalize_tfpws_band(value: str | None) -> str:
     return "FULL" if text in {"", "NONE", "OFF", "FULL", "ALL"} else text
 
 
+def _normalize_autocorr_mode(value: str | None) -> str:
+    text = "OFF" if value is None else str(value).strip().upper()
+    text = text.replace("-", "_")
+    if text in {"", "OFF", "NONE", "FALSE", "NO", "0"}:
+        return "off"
+    if text in {"INCLUDE", "ON", "TRUE", "YES", "1"}:
+        return "include"
+    if text in {"ONLY", "AUTO_ONLY", "AUTOCORR_ONLY", "SELF", "SELF_ONLY"}:
+        return "only"
+    return text.lower()
+
+
 def _normalize_optional_path(value: str | None) -> str:
     if value is None:
         return "NONE"
@@ -244,6 +256,7 @@ class Xcorr:
     distance_range:   str = "-1/50000"
     azimuth_range:    str = "-1/360"
     group_pair_mode:  str = "all"         # intra / inter / all
+    autocorr_mode:    str = "off"         # off / include / only
 
     @classmethod
     def from_cfg(cls, g: Mapping[str, str]) -> "Xcorr":
@@ -252,6 +265,7 @@ class Xcorr:
             distance_range   = g.get("distance_range", "-1/50000"),
             azimuth_range    = g.get("azimuth_range", "-1/360"),
             group_pair_mode  = g.get("group_pair_mode", "all").strip().lower(),
+            autocorr_mode    = _normalize_autocorr_mode(g.get("autocorr_mode", "off")),
         )
 
     def validate(self) -> None:
@@ -269,6 +283,8 @@ class Xcorr:
             "cross",
         }:
             raise ValueError("group_pair_mode must be intra, inter, or all")
+        if self.autocorr_mode not in {"off", "include", "only"}:
+            raise ValueError("autocorr_mode must be off, include, or only")
         self._check_range(self.distance_range, "distance_range")
         self._check_range(self.azimuth_range,  "azimuth_range")
 

--- a/fastxc/config_parser/tests/test_loader_layout.py
+++ b/fastxc/config_parser/tests/test_loader_layout.py
@@ -61,6 +61,7 @@ phase_only = True
 distance_range = 10/20
 azimuth_range = 30/40
 group_pair_mode = inter
+autocorr_mode = only
 windows_per_xcache = 12
 xcache_async_after_sac2spec = False
 async_poll_sec = 3
@@ -83,6 +84,7 @@ unpack_target = STACK
         self.assertEqual(cfg.xcorr.distance_range, "10/20")
         self.assertEqual(cfg.xcorr.azimuth_range, "30/40")
         self.assertEqual(cfg.xcorr.group_pair_mode, "inter")
+        self.assertEqual(cfg.xcorr.autocorr_mode, "only")
         self.assertEqual(cfg.stack.stack_flag, "111")
         self.assertEqual(cfg.stack.pre_stack_size, 7)
         self.assertEqual(cfg.xcache.windows_per_xcache, 12)

--- a/fastxc/inventory/builder.py
+++ b/fastxc/inventory/builder.py
@@ -59,7 +59,7 @@ def build_inventory(config: Any) -> InventoryResult:
         distance_range=config.xcorr.distance_range,
         azimuth_range=config.xcorr.azimuth_range,
         double_array=config.is_double_array,
-        allow_autocorr=False,
+        autocorr_mode=config.xcorr.autocorr_mode,
         group_pair_mode=config.xcorr.group_pair_mode,
         external_geo_tsv_path=config.geometry.external_geo_tsv,
     )

--- a/fastxc/inventory/planner.py
+++ b/fastxc/inventory/planner.py
@@ -67,6 +67,7 @@ class PathRecord:
 @dataclass(frozen=True)
 class PairFilterConfig:
     allow_autocorr: bool = True
+    autocorr_only: bool = False
     group_pair_mode: str = "all"
     use_distance_filter: bool = False
     min_distance_km: float = 0.0
@@ -109,6 +110,7 @@ def build_path_plan(
     azimuth_range: str = "-1/360",
     double_array: bool = False,
     allow_autocorr: bool = True,
+    autocorr_mode: str | None = None,
     group_pair_mode: str | None = None,
     external_geo_tsv_path: str | Path | None = None,
 ) -> PathPlan:
@@ -123,6 +125,7 @@ def build_path_plan(
         azimuth_range=azimuth_range,
         double_array=double_array,
         allow_autocorr=allow_autocorr,
+        autocorr_mode=autocorr_mode,
         group_pair_mode=group_pair_mode,
     )
     paths, pair_checks_total = build_valid_paths(nodes, config)
@@ -305,8 +308,12 @@ def build_valid_paths(
     pair_checks_total = 0
 
     for src_index, src in enumerate(nodes):
-        rec_start = src_index if config.allow_autocorr else src_index + 1
-        for rec in nodes[rec_start:]:
+        if config.autocorr_only:
+            candidates = [nodes[src_index]]
+        else:
+            rec_start = src_index if config.allow_autocorr else src_index + 1
+            candidates = nodes[rec_start:]
+        for rec in candidates:
             pair_checks_total += 1
             record = _build_path_record_if_valid(src, rec, config)
             if record is not None:
@@ -496,12 +503,15 @@ def parse_pair_filter_config(
     azimuth_range: str,
     double_array: bool,
     allow_autocorr: bool,
+    autocorr_mode: str | None = None,
     group_pair_mode: str | None = None,
 ) -> PairFilterConfig:
     use_distance, min_distance, max_distance = _parse_distance_range(distance_range)
     use_azimuth, azimuth_ranges = _parse_azimuth_range(azimuth_range)
+    autocorr = _normalize_autocorr_mode(autocorr_mode, allow_autocorr)
     return PairFilterConfig(
-        allow_autocorr=allow_autocorr,
+        allow_autocorr=autocorr != "off",
+        autocorr_only=autocorr == "only",
         group_pair_mode=_normalize_group_pair_mode(group_pair_mode, double_array),
         use_distance_filter=use_distance,
         min_distance_km=min_distance,
@@ -548,6 +558,19 @@ def _normalize_group_pair_mode(mode: str | None, double_array: bool) -> str:
     if value in {"inter", "between", "cross", "cross_group_only"}:
         return "cross_group_only"
     raise ValueError(f"unsupported group_pair_mode: {mode!r}")
+
+
+def _normalize_autocorr_mode(mode: str | None, allow_autocorr: bool) -> str:
+    if mode is None:
+        return "include" if allow_autocorr else "off"
+    value = str(mode).strip().lower().replace("-", "_")
+    if value in {"", "off", "none", "false", "no", "0"}:
+        return "off"
+    if value in {"include", "on", "true", "yes", "1"}:
+        return "include"
+    if value in {"only", "auto_only", "autocorr_only", "self", "self_only"}:
+        return "only"
+    raise ValueError(f"unsupported autocorr_mode: {mode!r}")
 
 
 @dataclass(frozen=True)
@@ -608,9 +631,12 @@ def _build_path_record_if_valid(
     rec: GeoNode,
     config: PairFilterConfig,
 ) -> PathRecord | None:
-    if src.gnsl == rec.gnsl and not config.allow_autocorr:
+    is_autocorr = src.gnsl == rec.gnsl
+    if is_autocorr and not config.allow_autocorr:
         return None
-    if not _passes_group_rule(src.group, rec.group, config.group_pair_mode):
+    if config.autocorr_only and not is_autocorr:
+        return None
+    if not is_autocorr and not _passes_group_rule(src.group, rec.group, config.group_pair_mode):
         return None
 
     distance_km = None

--- a/fastxc/inventory/tests/test_path_planner.py
+++ b/fastxc/inventory/tests/test_path_planner.py
@@ -224,6 +224,23 @@ class TestPathPlanner(unittest.TestCase):
         self.assertEqual(len(inter.paths), 2)
         self.assertEqual(len(all_pairs.paths), 3)
 
+    def test_autocorr_mode_controls_self_pairs(self):
+        files_group = {
+            ("STA01", self.timestamp): self._station_info("STA01", 0.0, 0.0),
+            ("STA02", self.timestamp): self._station_info("STA02", 0.0, 0.1),
+        }
+
+        off = build_path_plan(files_group, autocorr_mode="off")
+        include = build_path_plan(files_group, autocorr_mode="include")
+        only = build_path_plan(files_group, autocorr_mode="only")
+
+        self.assertEqual([path.path_id_text for path in off.paths], ["00010002"])
+        self.assertEqual(
+            [path.path_id_text for path in include.paths],
+            ["00010001", "00010002", "00020002"],
+        )
+        self.assertEqual([path.path_id_text for path in only.paths], ["00010001", "00020002"])
+
     def _station_info(self, station: str, lat: float, lon: float, network: str = "XX"):
         paths = []
         for component in ("E", "N", "Z"):

--- a/fastxc/resources/template.ini
+++ b/fastxc/resources/template.ini
@@ -85,6 +85,9 @@ phase_only = False
 distance_range = -1/50000
 azimuth_range = -1/360
 group_pair_mode = all
+; off excludes station self-pairs. include adds self-pairs to the selected
+; station-pair set. only keeps self-pairs only.
+autocorr_mode = off
 ; AUTO keeps every window from one timestamp SEGSPEC set in one .xcspec.
 ; Set a positive integer to write one .xcspec per N windows.
 windows_per_xcache = AUTO


### PR DESCRIPTION
## Summary

Expose autocorrelation path selection through the public INI configuration.

## Changes

- Add `[advance.compute].autocorr_mode` with `off`, `include`, and `only` modes.
- Wire the option from config parsing into inventory path planning.
- Preserve the existing default behavior with `autocorr_mode = off`.
- Show the resolved mode in `fastxc doctor`.
- Update the template, example config, README files, and configuration/output docs.
- Add tests for config parsing and path planner behavior.

## Validation

- `python -m pytest fastxc`
- `python -m fastxc.cli doctor example/config.ini`

## Notes

This keeps the existing `allow_autocorr` lower-level API compatible while making autocorrelation usable from normal FastXC workflows. `include` adds station self-pairs to the normal pair set, while `only` keeps self-pairs only.