### PR TITLE
Fix CUDA arch normalization for sm_120

### DIFF
--- a/native/common.mk
+++ b/native/common.mk
@@ -31,7 +31,7 @@ CUDA_ARCH_FALLBACK ?= sm_80
 CUDA_ARCH_DETECTOR ?= $(CUDA_SRC_ROOT)/detect_cuda_archs.sh
 CHECK_GPU ?= $(CUDA_SRC_ROOT)/../tools/check_gpu
 
-normalize_sm = $(if $(filter sm_%,$(1)),$(1),sm_$(1))
+normalize_sm = $(shell printf '%s\n' '$(1)' | awk '{ arch=$$0; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", arch); sub(/^sm_/, "", arch); sub(/^compute_/, "", arch); if (arch ~ /^[0-9]+[.][0-9]+$$/) { split(arch, parts, "."); printf "sm_%s%s", parts[1], parts[2] } else { printf "sm_%s", arch } }')
 
 ifeq ($(strip $(ARCH)),auto)
   DETECTED_ARCHS := $(strip $(shell \

--- a/native/detect_cuda_archs.sh
+++ b/native/detect_cuda_archs.sh
@@ -16,12 +16,29 @@ run_probe() {
 
 normalize_archs() {
   awk '
+    function trim(s) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+      return s
+    }
+    function emit(major, minor) {
+      if (major ~ /^[1-9][0-9]*$/ && minor ~ /^[0-9]+$/) {
+        print "sm_" major minor
+      }
+    }
+    function normalize(arch) {
+      arch = trim(arch)
+      if (arch == "") return
+      sub(/^sm_/, "", arch)
+      sub(/^compute_/, "", arch)
+      if (arch ~ /^[0-9]+[.][0-9]+$/) {
+        split(arch, parts, ".")
+        emit(parts[1], parts[2])
+        return
+      }
+      if (arch ~ /^[1-9][0-9]+$/) print "sm_" arch
+    }
     {
-      gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-      if ($0 == "") next
-      gsub(/^sm_/, "", $0)
-      gsub(/\./, "", $0)
-      if ($0 ~ /^[1-9][0-9]$/) print "sm_" $0
+      for (i = 1; i <= NF; i++) normalize($i)
     }
   ' | sort -u | tr '\n' ' '
 }


### PR DESCRIPTION
## Summary

- Parse CUDA compute capability as `major.minor` so `12.0` becomes `sm_120` while legacy values such as `8.9` and `1.2` remain `sm_89` and `sm_12`.
- Normalize manual `ARCH=` values in `native/common.mk` so `ARCH=12.0`, `ARCH=120`, and `ARCH=sm_120` all produce `compute_120,code=sm_120`.
- Make the detector robust to whitespace-separated architecture tokens during final normalization.

## Why

RTX 50-series devices such as RTX 5060 report CUDA capability 12.0. The old detector accepted only two-digit SM values, so auto builds could fall back to `sm_80` and later fail with `cudaErrorNoKernelImageForDevice`.

## Validation

- `make -C native print-config ARCH=auto CUDA_ARCH_FALLBACK=12.0 CHECK_GPU=/not/exist CUDA_ARCH_PROBE_TIMEOUT=0s`
- `make -C native print-config ARCH=12.0`
- `make -C native print-config ARCH=120`
- `make -C native print-config ARCH=sm_120`
- `make -C native print-config ARCH=8.9`
- `make -C native print-config ARCH=1.2`