### PR TITLE
[codex] Fix native CUDA build and sac2dat suffix handling

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -40,6 +40,39 @@ CUDA architecture is auto-detected. If detection fails, override it explicitly:
 make install ARCH=sm_89
 ```
 
+Set `ARCH` from the GPU compute capability: for example, 8.9 maps to `sm_89`
+and 12.0 maps to `sm_120`. Forms such as `sm89`, `sm120`, `8.9`, and `12.0`
+are also accepted and normalized to `sm_XX`. If you change GPUs, change
+`ARCH`, or suspect the existing native binaries under `bin/` were built for an
+older architecture, clean the native outputs before reinstalling:
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX
+```
+
+Replace `sm_XX` with the architecture for the current GPU. If auto-detection
+works, `ARCH` can be omitted. You usually do not need to set compiler paths
+manually. Only set `NVCC`/`CUDA_HOME` when `make` finds an incomplete or wrong
+`nvcc`, for example:
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX \
+  NVCC=/path/to/cuda/bin/nvcc CUDA_HOME=/path/to/cuda
+```
+
+If you use Miniconda/Conda CUDA, make sure the environment provides a complete
+CUDA Toolkit, including `nvcc`, `cufft.h`, and `libcufft.so`. The build checks
+both `$CUDA_HOME/include` and target layouts such as
+`$CUDA_HOME/targets/x86_64-linux/include`. If `nvcc` is incompatible with the
+default host compiler, set real C/C++ compiler paths:
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX CC=/path/to/gcc CXX=/path/to/g++
+```
+
 ## Install
 
 All commands below assume the current directory is the FastXC repository root,

--- a/README.md
+++ b/README.md
@@ -38,6 +38,36 @@ CUDA 架构默认自动检测。如果自动检测失败，可以手动指定：
 make install ARCH=sm_89
 ```
 
+其中 `ARCH` 应该按当前 GPU 的 compute capability 设置，例如 8.9 对应
+`sm_89`，12.0 对应 `sm_120`。也可以写成 `sm89`、`sm120` 或 `8.9`、
+`12.0`，构建系统会规范化为 `sm_XX`。如果更换 GPU、修改 `ARCH`，或怀疑已有
+`bin/` 里的原生二进制是按旧架构编译的，请先清理旧 native 产物再安装：
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX
+```
+
+把 `sm_XX` 替换成当前 GPU 对应的架构；自动检测正常时也可以省略 `ARCH`。
+通常不需要手动设置编译器路径。只有当 `make` 选到了不完整或错误的 `nvcc`
+时，才显式指定 `NVCC`/`CUDA_HOME`，例如：
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX \
+  NVCC=/path/to/cuda/bin/nvcc CUDA_HOME=/path/to/cuda
+```
+
+如果使用 Miniconda/Conda 里的 CUDA，请确认该环境提供完整 CUDA Toolkit，
+包括 `nvcc`、`cufft.h` 和 `libcufft.so`。构建系统会同时检查
+`$CUDA_HOME/include` 和 `$CUDA_HOME/targets/x86_64-linux/include` 这类布局。
+当 `nvcc` 不兼容默认 host compiler 时，再指定真实存在的 C/C++ 编译器：
+
+```bash
+make veryclean-native
+make install BUILD=release ARCH=sm_XX CC=/path/to/gcc CXX=/path/to/g++
+```
+
 ## 安装
 
 下面所有命令都假设当前目录是 FastXC 项目根目录，也就是能看到

--- a/fastxc/tools/sac2dat.py
+++ b/fastxc/tools/sac2dat.py
@@ -68,10 +68,14 @@ def convert_sac_dir(input_dir: str | Path, output_dir: str | Path) -> list[DatCo
         raise NotADirectoryError(input_dir)
 
     results: list[DatConversionResult] = []
-    for sac_path in sorted(input_dir.rglob("*.sac")):
+    for sac_path in _iter_sac_files(input_dir):
         rel_path = sac_path.relative_to(input_dir).with_suffix(".dat")
         results.append(sac_to_dat(sac_path, output_dir / rel_path))
     return results
+
+
+def _iter_sac_files(input_dir: Path) -> list[Path]:
+    return sorted(path for path in input_dir.rglob("*") if path.is_file() and path.suffix.lower() == ".sac")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/fastxc/tools/tests/test_sac2dat.py
+++ b/fastxc/tools/tests/test_sac2dat.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+
+from fastxc.io import SacHeader, write_sac
+from fastxc.tools.sac2dat import convert_sac_dir
+
+
+def test_convert_sac_dir_accepts_case_insensitive_sac_suffix(tmp_path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    lower = input_dir / "lower.sac"
+    upper = input_dir / "AA.BB" / "CC.DD.ncf.SAC"
+    mixed = input_dir / "nested" / "mixed.SaC"
+
+    for path in (lower, upper, mixed):
+        _write_test_sac(path)
+
+    results = convert_sac_dir(input_dir, output_dir)
+
+    assert len(results) == 3
+    assert (output_dir / "lower.dat").is_file()
+    assert (output_dir / "AA.BB" / "CC.DD.ncf.dat").is_file()
+    assert (output_dir / "nested" / "mixed.dat").is_file()
+
+
+def _write_test_sac(path):
+    header = SacHeader.empty()
+    header.set_int("npts", 4)
+    header.set_float("delta", 0.5)
+    write_sac(path, header, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))

--- a/native/Makefile
+++ b/native/Makefile
@@ -2,6 +2,7 @@
 
 BUILD ?= release
 include common.mk
+.DEFAULT_GOAL := all
 
 MODE ?= par
 ifeq ($(filter $(MODE),par seq),)
@@ -26,12 +27,12 @@ CLEAN_DIRS := $(BACKEND_DIRS)
 
 .PHONY: all debug recurse clean veryclean print-config help $(BACKEND_DIRS)
 
-all: ## Build all native backends in release mode by default
+all: cuda-preflight ## Build all native backends in release mode by default
 	@printf "\033[32m=== FastXC CUDA build: BUILD=%s MODE=%s ARCH=%s ===\033[0m\n" "$(BUILD)" "$(MODE)" "$(CUDA_SM)"
 	$(MAKE) $(PARFLAG) $(OSYNC) BUILD=$(BUILD) recurse
 
 debug: BUILD=debug
-debug: ## Build all native backends in debug mode
+debug: cuda-preflight ## Build all native backends in debug mode
 	@printf "\033[33m=== FastXC CUDA debug build: MODE=%s ARCH=%s ===\033[0m\n" "$(MODE)" "$(CUDA_SM)"
 	$(MAKE) $(PARFLAG) $(OSYNC) BUILD=$(BUILD) recurse
 
@@ -39,7 +40,7 @@ recurse: $(BUILD_DIRS)
 
 $(BACKEND_DIRS):
 	@printf "\033[35m========== [ %s ] =========\033[0m\n" "$@"
-	$(MAKE) -C "$@" BUILD=$(BUILD)
+	$(MAKE) -C "$@" BUILD=$(BUILD) all
 
 clean: ## Remove object files from all CUDA backend directories
 	@for dir in $(CLEAN_DIRS); do \
@@ -61,12 +62,17 @@ print-config: ## Show compiler and CUDA architecture settings
 	@printf "BUILD=%s\n" "$(BUILD)"
 	@printf "NVCC=%s\n" "$(NVCC)"
 	@printf "CUDA_HOME=%s\n" "$(CUDA_HOME)"
+	@printf "CUDA_INCLUDEDIR=%s\n" "$(CUDA_INCLUDEDIR)"
+	@printf "CUDA_LIBDIR=%s\n" "$(CUDA_LIBDIR)"
+	@printf "CUDA_STD=%s\n" "$(CUDA_STD)"
+	@printf "NVCC_CCBIN=%s\n" "$(NVCC_CCBIN)"
 	@printf "ARCH_REQUEST=%s\n" "$(ARCH)"
 	@printf "DETECTED_ARCHS=%s\n" "$(DETECTED_ARCHS)"
 	@printf "CUDA_SM=%s\n" "$(CUDA_SM)"
+	@printf "CUDA_COMPUTE=%s\n" "$(CUDA_COMPUTE)"
 	@printf "NVCC_ARCH_FLAGS=%s\n" "$(NVCC_ARCH_FLAGS)"
 
 help: ## Show this help
-	@awk 'BEGIN{FS=":.*##"; printf "\nUsage: make \033[36m<TARGET>\033[0m [MODE=par|seq] [BUILD=release|debug] [ARCH=auto|sm_89]\n\nTargets:\n"} \
+	@awk 'BEGIN{FS=":.*##"; printf "\nUsage: make \033[36m<TARGET>\033[0m [MODE=par|seq] [BUILD=release|debug] [ARCH=auto|sm_89|sm89|8.9]\n\nTargets:\n"} \
 	     /^[a-zA-Z0-9_-]+:[^#]*##/{printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}' \
 	     $(MAKEFILE_LIST)

--- a/native/common.mk
+++ b/native/common.mk
@@ -3,16 +3,31 @@
 CUDA_SRC_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 CC   ?= gcc
+CXX  ?= g++
 NVCC ?= $(shell command -v nvcc 2>/dev/null || \
           command -v /usr/local/cuda/bin/nvcc 2>/dev/null || \
           command -v /usr/local/cuda-12.6/bin/nvcc 2>/dev/null)
 
-CUDA_HOME   ?= $(patsubst %/bin/nvcc,%,$(NVCC))
-CUDA_LIBDIR ?= $(CUDA_HOME)/lib64
+CUDA_HOME ?= $(patsubst %/bin/nvcc,%,$(NVCC))
+CUDA_TARGET_TRIPLET ?= x86_64-linux
+CUDA_TARGET_ROOT := $(CUDA_HOME)/targets/$(CUDA_TARGET_TRIPLET)
+CUDA_TARGET_DIR ?= $(if $(wildcard $(CUDA_TARGET_ROOT)/include),$(CUDA_TARGET_ROOT),$(CUDA_HOME))
+CUDA_INCLUDEDIR ?= $(CUDA_TARGET_DIR)/include
+CUDA_LIBDIR ?= $(or $(firstword $(wildcard $(CUDA_TARGET_DIR)/lib $(CUDA_HOME)/lib64 $(CUDA_HOME)/lib)),$(CUDA_HOME)/lib64)
 
 WARN     ?= -Wall
 BITS64   ?= -D_FILE_OFFSET_BITS=64
-CINCLUDE ?= -I$(CUDA_HOME)/include
+CINCLUDE ?= -I$(CUDA_INCLUDEDIR)
+CUDA_STD ?= c++17
+
+ifeq ($(origin NVCC_CCBIN),undefined)
+  ifneq ($(filter command line environment environment override,$(origin CXX)),)
+    NVCC_CCBIN := $(CXX)
+  else
+    NVCC_CCBIN :=
+  endif
+endif
+NVCC_CCBIN_FLAG = $(if $(strip $(NVCC_CCBIN)),-ccbin $(NVCC_CCBIN),)
 
 # Direct subdirectory builds default to debug. The top-level Makefile overrides
 # this to release unless BUILD=debug is requested.
@@ -31,7 +46,7 @@ CUDA_ARCH_FALLBACK ?= sm_80
 CUDA_ARCH_DETECTOR ?= $(CUDA_SRC_ROOT)/detect_cuda_archs.sh
 CHECK_GPU ?= $(CUDA_SRC_ROOT)/../tools/check_gpu
 
-normalize_sm = $(shell printf '%s\n' '$(1)' | awk '{ arch=$$0; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", arch); sub(/^sm_/, "", arch); sub(/^compute_/, "", arch); if (arch ~ /^[0-9]+[.][0-9]+$$/) { split(arch, parts, "."); printf "sm_%s%s", parts[1], parts[2] } else { printf "sm_%s", arch } }')
+normalize_sm = $(shell printf '%s\n' '$(1)' | awk '{ arch=$$0; gsub(/^[[:space:]]+|[[:space:]]+$$/, "", arch); sub(/^(sm_|sm|compute_|compute)/, "", arch); if (arch ~ /^[0-9]+[.][0-9]+$$/) { split(arch, parts, "."); printf "sm_%s%s", parts[1], parts[2] } else { printf "sm_%s", arch } }')
 
 ifeq ($(strip $(ARCH)),auto)
   DETECTED_ARCHS := $(strip $(shell \
@@ -45,7 +60,14 @@ else
 endif
 
 sm_version = $(patsubst sm_%,%,$(1))
-NVCC_ARCH_FLAGS := -gencode arch=compute_$(call sm_version,$(CUDA_SM)),code=$(CUDA_SM)
+CUDA_COMPUTE := compute_$(call sm_version,$(CUDA_SM))
+NVCC_ARCH_FLAGS := -gencode arch=$(CUDA_COMPUTE),code=$(CUDA_SM)
+CUDA_REQUIRED_CPPFLAGS := $(CINCLUDE)
+CUDA_REQUIRED_NVCCFLAGS := -std=$(CUDA_STD) $(NVCC_ARCH_FLAGS) $(NVCC_CCBIN_FLAG)
+CUDA_LDFLAGS := -L$(CUDA_LIBDIR)
+CUDA_CUFFT_HEADER := $(CUDA_INCLUDEDIR)/cufft.h
+CUDA_CUFFT_LIB := $(firstword $(wildcard $(CUDA_LIBDIR)/libcufft.so $(CUDA_LIBDIR)/libcufft_static.a))
+CUDA_CUDART_LIB := $(firstword $(wildcard $(CUDA_LIBDIR)/libcudart.so $(CUDA_LIBDIR)/libcudart_static.a))
 
 ifeq ($(BUILD),debug)
   OPT_CFLAGS    ?= -O0 -g
@@ -54,3 +76,33 @@ else
   OPT_CFLAGS    ?= -O3
   OPT_NVCCFLAGS ?= -O3 --use_fast_math --generate-line-info
 endif
+
+.PHONY: cuda-preflight
+
+cuda-preflight:
+	@{ test -n "$(NVCC)" && test -x "$(NVCC)"; } || { \
+	  echo "ERROR: nvcc not found. Put nvcc on PATH or set NVCC=/path/to/cuda/bin/nvcc."; \
+	  exit 1; \
+	}
+	@if "$(NVCC)" --list-gpu-arch >/dev/null 2>&1; then \
+	  "$(NVCC)" --list-gpu-arch | grep -qx "$(CUDA_COMPUTE)" || { \
+	    echo "ERROR: $(NVCC) does not support $(CUDA_COMPUTE) ($(CUDA_SM))."; \
+	    echo "Use a newer CUDA Toolkit for this GPU, or set ARCH to a supported architecture."; \
+	    exit 1; \
+	  }; \
+	fi
+	@test -f "$(CUDA_CUFFT_HEADER)" || { \
+	  echo "ERROR: cuFFT header not found: $(CUDA_CUFFT_HEADER)"; \
+	  echo "If using conda CUDA, install a complete CUDA Toolkit or set CUDA_HOME/NVCC to the toolkit root."; \
+	  exit 1; \
+	}
+	@test -n "$(CUDA_CUFFT_LIB)" || { \
+	  echo "ERROR: cuFFT library not found in $(CUDA_LIBDIR)"; \
+	  echo "If using conda CUDA, install a complete CUDA Toolkit or set CUDA_HOME/NVCC to the toolkit root."; \
+	  exit 1; \
+	}
+	@test -n "$(CUDA_CUDART_LIB)" || { \
+	  echo "ERROR: CUDA runtime library not found in $(CUDA_LIBDIR)"; \
+	  echo "If using conda CUDA, install a complete CUDA Toolkit or set CUDA_HOME/NVCC to the toolkit root."; \
+	  exit 1; \
+	}

--- a/native/pws/Makefile
+++ b/native/pws/Makefile
@@ -1,15 +1,16 @@
 # PWS-only stack backend.
 
 include ../common.mk
-
-CUDA_STD ?= c++11
+.DEFAULT_GOAL := all
 
 INCLUDES := -I. -Iinclude -Iio -Ikernels -Iworker
+PROJECT_CPPFLAGS := $(INCLUDES) $(CUDA_REQUIRED_CPPFLAGS)
+NVCC_HOST_FLAGS := -Xcompiler "$(BITS64),-pthread"
 
-CFLAGS    ?= $(OPT_CFLAGS) $(WARN) $(INCLUDES) -pthread $(BITS64) $(CINCLUDE)
-NVCCFLAGS ?= $(OPT_NVCCFLAGS) -std=$(CUDA_STD) $(NVCC_ARCH_FLAGS) $(INCLUDES) -Xcompiler "$(BITS64),-pthread" $(CINCLUDE)
+CFLAGS    ?= $(OPT_CFLAGS) $(WARN)
+NVCCFLAGS ?= $(OPT_NVCCFLAGS)
 
-LDFLAGS = -L$(CUDA_LIBDIR) -lcufft -lcudart -lm -lpthread
+LDFLAGS = $(CUDA_LDFLAGS) -lcufft -lcudart -lm -lpthread
 
 CUDAOBJS = \
     cuda.util.o \
@@ -36,13 +37,13 @@ $(BINDIR):
 	@mkdir -p $@
 
 $(PROG): $(OBJS) $(CUDAOBJS)
-	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LDFLAGS)
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) $(NVCC_HOST_FLAGS) -o $@ $^ $(LDFLAGS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(PROJECT_CPPFLAGS) $(CFLAGS) -pthread $(BITS64) -c $< -o $@
 
 %.o: %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) $(NVCC_HOST_FLAGS) -c $< -o $@
 
 cuda.main.o: worker/gpu_config.hpp worker/sourcepack_pipeline.hpp include/logger.h
 arguproc.o: include/logger.h

--- a/native/sac2spec/Makefile
+++ b/native/sac2spec/Makefile
@@ -1,14 +1,14 @@
 # sac2spec backend.
 
 include ../common.mk
-
-CUDA_STD ?= c++14
+.DEFAULT_GOAL := all
 
 INCLUDES  := -I. -Iinclude
-CFLAGS    ?= $(OPT_CFLAGS) $(WARN) $(INCLUDES)
-NVCCFLAGS ?= $(OPT_NVCCFLAGS) -std=$(CUDA_STD) $(NVCC_ARCH_FLAGS) $(INCLUDES)
+PROJECT_CPPFLAGS := $(INCLUDES) $(CUDA_REQUIRED_CPPFLAGS)
+CFLAGS    ?= $(OPT_CFLAGS) $(WARN)
+NVCCFLAGS ?= $(OPT_NVCCFLAGS)
 
-LFLAG = -L$(CUDA_LIBDIR) -lcufft -lcudart -lm -lpthread
+LFLAG = $(CUDA_LDFLAGS) -lcufft -lcudart -lm -lpthread
 
 CUDAOBJS = \
     cuda.util.o \
@@ -63,13 +63,13 @@ $(BINDIR):
 	@mkdir -p $@
 
 $(PROG): $(OBJS) $(CUDAOBJS) $(KERNELOBJS) $(CORECUDAOBJS)
-	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LFLAG)
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) -o $@ $^ $(LFLAG)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(PROJECT_CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 %.o: %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) -c $< -o $@
 
 clean:
 	@rm -f *.o core/*.o io/*.o kernels/*.o worker/*.o

--- a/native/tfpws/Makefile
+++ b/native/tfpws/Makefile
@@ -1,15 +1,16 @@
 # TF-PWS-only stack backend.
 
 include ../common.mk
-
-CUDA_STD ?= c++14
+.DEFAULT_GOAL := all
 
 INCLUDES := -I. -Iinclude -Iio -Iworker -Icore -Ikernels
+PROJECT_CPPFLAGS := $(INCLUDES) $(CUDA_REQUIRED_CPPFLAGS)
+NVCC_HOST_FLAGS := -Xcompiler "$(BITS64),-pthread"
 
-CFLAGS    ?= $(OPT_CFLAGS) $(WARN) -pthread $(BITS64) $(CINCLUDE) $(INCLUDES)
-NVCCFLAGS ?= $(OPT_NVCCFLAGS) -std=$(CUDA_STD) $(NVCC_ARCH_FLAGS) -Xcompiler "$(BITS64),-pthread" $(CINCLUDE) $(INCLUDES)
+CFLAGS    ?= $(OPT_CFLAGS) $(WARN)
+NVCCFLAGS ?= $(OPT_NVCCFLAGS)
 
-LDFLAGS = -L$(CUDA_LIBDIR) -lcufft -lcudart -lm -lpthread
+LDFLAGS = $(CUDA_LDFLAGS) -lcufft -lcudart -lm -lpthread
 
 CUDAOBJS = \
     kernels/cuda.stransform.o \
@@ -37,13 +38,13 @@ $(BINDIR):
 	@mkdir -p $@
 
 $(PROG): $(OBJS) $(CUDAOBJS)
-	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LDFLAGS)
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) $(NVCC_HOST_FLAGS) -o $@ $^ $(LDFLAGS)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(PROJECT_CPPFLAGS) $(CFLAGS) -pthread $(BITS64) -c $< -o $@
 
 %.o: %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) $(NVCC_HOST_FLAGS) -c $< -o $@
 
 cuda.main.o: include/tfpws_types.hpp include/tfpws_input.hpp include/tfpws_schedule.hpp worker/pipeline.hpp cuda.util.cuh include/logger.h
 cuda.util.o: cuda.util.cuh include/logger.h

--- a/native/xc/Makefile
+++ b/native/xc/Makefile
@@ -1,14 +1,15 @@
 # xc_fast backend.
 
 include ../common.mk
+.DEFAULT_GOAL := all
 
-CUDA_STD ?= c++14
 INCLUDES := -I. -Iinclude -Iio -Iworker -Imemory -Ikernels -Ipack_io
+PROJECT_CPPFLAGS := $(INCLUDES) $(CUDA_REQUIRED_CPPFLAGS)
 
-CFLAGS    ?= $(OPT_CFLAGS) $(WARN) $(INCLUDES) -pthread
-NVCCFLAGS ?= $(OPT_NVCCFLAGS) -std=$(CUDA_STD) $(NVCC_ARCH_FLAGS) $(INCLUDES)
+CFLAGS    ?= $(OPT_CFLAGS) $(WARN)
+NVCCFLAGS ?= $(OPT_NVCCFLAGS)
 
-LFLAG = -L$(CUDA_LIBDIR) -lcufft -lcudart -lm -lpthread
+LFLAG = $(CUDA_LDFLAGS) -lcufft -lcudart -lm -lpthread
 
 CUDAOBJS = \
     cuda.main.o \
@@ -42,13 +43,13 @@ $(BINDIR):
 	@mkdir -p $@
 
 $(PROG): $(OBJS) $(CUDAOBJS)
-	$(NVCC) $(NVCCFLAGS) -o $@ $^ $(LFLAG)
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) -o $@ $^ $(LFLAG)
 
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(PROJECT_CPPFLAGS) $(CFLAGS) -pthread -c $< -o $@
 
 %.o: %.cu
-	$(NVCC) $(NVCCFLAGS) -c $< -o $@
+	$(NVCC) $(PROJECT_CPPFLAGS) $(NVCCFLAGS) $(CUDA_REQUIRED_NVCCFLAGS) -c $< -o $@
 
 arguproc.o cuda.main.o memory/memory.o io/input.o: arguproc.h
 cuda.main.o worker/async_workers.o memory/memory.o: memory/memory.hpp


### PR DESCRIPTION
## What changed

- Hardened the native CUDA Makefile configuration for Conda/Miniconda CUDA toolkits, CUDA target include/lib paths, host compiler selection, and architecture normalization such as `sm120`/`12.0` -> `sm_120`.
- Added native CUDA preflight checks so unsupported architectures and missing CUDA/cuFFT pieces fail early with clearer messages.
- Updated README build guidance around clean native rebuilds, `ARCH`, `NVCC`/`CUDA_HOME`, and optional host compiler overrides.
- Fixed `fastxc sac2dat` so it detects SAC files case-insensitively, including unpacked `.ncf.SAC` outputs.
- Added a focused test covering `.sac`, `.SAC`, and mixed-case `.SaC` suffixes.

## Why

Users running from Miniconda CUDA environments were hitting stale native binaries, missing target include/lib paths, architecture normalization bugs, and host compiler incompatibilities. Separately, the example pipeline auto-unpacks to `.ncf.SAC`, but `sac2dat` only scanned lowercase `*.sac`, so converting unpacked example output could silently convert zero files.

## Validation

- `make -C native print-config ARCH=sm120`
- `make -C native print-config ARCH=compute120`
- `make -C native print-config ARCH=12.0`
- `make -C native print-config ARCH=sm_120 CXX=g++-11`
- `make -C native cuda-preflight ARCH=sm80`
- `make -C native cuda-preflight ARCH=sm120` confirms early unsupported-arch failure on the local CUDA toolkit
- `make -C native BUILD=release ARCH=sm80 all`
- `python -m pytest -q fastxc/tools/tests/test_sac2dat.py`